### PR TITLE
Added static musl generation.

### DIFF
--- a/mussel.sh
+++ b/mussel.sh
@@ -657,8 +657,7 @@ CROSS_COMPILE=$XTARGET- \
 LIBCC="$MPREFIX/lib/gcc/$XTARGET/$gcc_ver/libgcc.a" \
 ./configure \
   --host=$XTARGET \
-  --prefix=/usr \
-  --disable-static >> $MLOG 2>&1
+  --prefix=/usr >> $MLOG 2>&1
 
 printf -- "${BLUEC}..${NORMALC} Building musl...\n"
 $MAKE \


### PR DESCRIPTION
Generation of static libraries was disabled in musl's configuration,
however it causes some problems when statically linking binaries.
For instance, make's configure script considers without that that
the compiler doesn't work if make is linked statically.