### PR TITLE
Use LARCH instead of MARCH for x86-64 pkgconf symlink

### DIFF
--- a/mussel.sh
+++ b/mussel.sh
@@ -677,7 +677,7 @@ if [ $PKG_CONFIG_SUPPORT = yes ]; then
 
   ln -sv pkgconf $MPREFIX/bin/pkg-config >> $MLOG 2>&1
   # Different architectures require different names
-  if [ $XARCH == "x86-64" ]; then
+  if [ "$XARCH" = "x86-64" ]; then
     ln -sv pkgconf $MPREFIX/bin/${LARCH}-linux-musl-pkgconf >> $MLOG 2>&1
     ln -sv pkgconf $MPREFIX/bin/${LARCH}-linux-musl-pkg-config >> $MLOG 2>&1
   else


### PR DESCRIPTION
Also includes commit 14ed7b4

pkgconf needs x86_64 (LARCH) instead of x86-64 (XARCH) for its executable name. Everything else can stay XARCH. 