### PR TITLE
Implement an alternative for b3sum and wget

### DIFF
--- a/mussel.sh
+++ b/mussel.sh
@@ -134,7 +134,7 @@ nettransfer(){
 	fname="${url##*/}"
 	printf ' %-*s%s' $col "" "$fname" 1>&2
 	COLUMNS=$col curl -o "$fname" -L -# "$url"
-	unset col fname url	
+	unset col fname url
 }
 # A tribute for slackpkg folks
 elif command -v lynx 2>&1 > /dev/null; then
@@ -163,7 +163,7 @@ printf -- '%b!!%b There'\''s no URL transfer utility installed at this system (s
 printf -- '%b!.%b Go and get one of those, it'\''s free, gratis, buckshee:\n%s\n%s\n%s\n%s\n%s\n' \
 	"$YELLOWC" "$NORMALC" \
 	'https://aria2.github.io' 'https://curl.se' \
-       	'https://lynx.invisible-island.net' 'https://w3m.sourceforge.net' \
+	'https://lynx.invisible-island.net' 'https://w3m.sourceforge.net' \
 	'https://www.gnu.org/software/wget/ (C'\''mon, it'\''s better than nothing)'
 exit 1
 fi


### PR DESCRIPTION
This is helpful for Copacabana Linux® since we don't have ``rustc``/``cargo`` for building ``b3sum`` neither have GNU wget on the system, so providing alternatives helps in terms of compatibility with different environments.
Also, in the support for other URL transfer programs, I gave priority for aria2c, which can transfer larger files such as the GNU Compiler Collection source a lot faster than cURL, Lynx, w3m or GNU wget.
I hope this helps and also fixes #13.