### PR TITLE
fix : b3sum checksum bug

### DIFF
--- a/mussel.sh
+++ b/mussel.sh
@@ -457,7 +457,7 @@ mpackage() {
   fi
 
   printf -- "${BLUEC}..${NORMALC} Verifying "$HOLDER"...\n"
-  printf -- "$3 $HOLDER" | checksum || {
+  printf -- "$3  $HOLDER" | checksum || {
     printf -- "${YELLOWC}!.${NORMALC} "$HOLDER" is corrupted, redownloading...\n" &&
     rm "$HOLDER" &&
     nettransfer "$2";


### PR DESCRIPTION
`b3sum -c` fails when there is only one space between checksum and filename.