### PR TITLE
add m68k, SuperH, and additional arm targets; bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ Sources will be preserved.
 
 ## Supported Architectures
 * aarch64
+* armv4t
+* armv5te
+* armv6
 * armv6kz (Raspberry Pi 1 Models A, B, B+, the Compute Module, and the Raspberry
 Pi Zero)
 * armv7
+* i486
 * i586
 * i686
+* m68k
 * microblaze
 * microblazeel
 * mips64
@@ -68,10 +73,17 @@ Pi Zero)
 * mipsisa64r6el
 * or1k
 * powerpc
+* powerpcle
 * powerpc64
 * powerpc64le
 * riscv64
 * s390x
+* sh2
+* sh2be
+* sh2-fdpic
+* sh2be-fdpic
+* sh4
+* sh4be
 * x86-64
 
 ## Packages

--- a/meson/meson.cross.armv4t
+++ b/meson/meson.cross.armv4t
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'armv4t-linux-musleabihf-gcc-ar'
+as = 'armv4t-linux-musleabihf-as'
+c = 'armv4t-linux-musleabihf-gcc'
+c_ld = 'bfd'
+cpp = 'armv4t-linux-musleabihf-g++'
+cpp_ld = 'bfd'
+ld = 'armv4t-linux-musleabihf-ld.bfd'
+nm = 'armv4t-linux-musleabihf-gcc-nm'
+objcopy = 'armv4t-linux-musleabihf-objcopy'
+objdump = 'armv4t-linux-musleabihf-objdump'
+ranlib = 'armv4t-linux-musleabihf-gcc-ranlib'
+readelf = 'armv4t-linux-musleabihf-readelf'
+size = 'armv4t-linux-musleabihf-size'
+strings = 'armv4t-linux-musleabihf-strings'
+strip = 'armv4t-linux-musleabihf-strip'
+
+[host_machine]
+cpu = 'armv4t'
+cpu_family = 'arm'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.armv5te
+++ b/meson/meson.cross.armv5te
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'armv5te-linux-musleabihf-gcc-ar'
+as = 'armv5te-linux-musleabihf-as'
+c = 'armv5te-linux-musleabihf-gcc'
+c_ld = 'bfd'
+cpp = 'armv5te-linux-musleabihf-g++'
+cpp_ld = 'bfd'
+ld = 'armv5te-linux-musleabihf-ld.bfd'
+nm = 'armv5te-linux-musleabihf-gcc-nm'
+objcopy = 'armv5te-linux-musleabihf-objcopy'
+objdump = 'armv5te-linux-musleabihf-objdump'
+ranlib = 'armv5te-linux-musleabihf-gcc-ranlib'
+readelf = 'armv5te-linux-musleabihf-readelf'
+size = 'armv5te-linux-musleabihf-size'
+strings = 'armv5te-linux-musleabihf-strings'
+strip = 'armv5te-linux-musleabihf-strip'
+
+[host_machine]
+cpu = 'armv5te'
+cpu_family = 'arm'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.armv6
+++ b/meson/meson.cross.armv6
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'armv6-linux-musleabihf-gcc-ar'
+as = 'armv6-linux-musleabihf-as'
+c = 'armv6-linux-musleabihf-gcc'
+c_ld = 'bfd'
+cpp = 'armv6-linux-musleabihf-g++'
+cpp_ld = 'bfd'
+ld = 'armv6-linux-musleabihf-ld.bfd'
+nm = 'armv6-linux-musleabihf-gcc-nm'
+objcopy = 'armv6-linux-musleabihf-objcopy'
+objdump = 'armv6-linux-musleabihf-objdump'
+ranlib = 'armv6-linux-musleabihf-gcc-ranlib'
+readelf = 'armv6-linux-musleabihf-readelf'
+size = 'armv6-linux-musleabihf-size'
+strings = 'armv6-linux-musleabihf-strings'
+strip = 'armv6-linux-musleabihf-strip'
+
+[host_machine]
+cpu = 'armv6'
+cpu_family = 'arm'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.i486
+++ b/meson/meson.cross.i486
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'i486-linux-musl-gcc-ar'
+as = 'i486-linux-musl-as'
+c = 'i486-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'i486-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'i486-linux-musl-ld.bfd'
+nm = 'i486-linux-musl-gcc-nm'
+objcopy = 'i486-linux-musl-objcopy'
+objdump = 'i486-linux-musl-objdump'
+ranlib = 'i486-linux-musl-gcc-ranlib'
+readelf = 'i486-linux-musl-readelf'
+size = 'i486-linux-musl-size'
+strings = 'i486-linux-musl-strings'
+strip = 'i486-linux-musl-strip'
+
+[host_machine]
+cpu = 'i486'
+cpu_family = 'x86'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.m68k
+++ b/meson/meson.cross.m68k
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'm68k-linux-musl-gcc-ar'
+as = 'm68k-linux-musl-as'
+c = 'm68k-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'm68k-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'm68k-linux-musl-ld.bfd'
+nm = 'm68k-linux-musl-gcc-nm'
+objcopy = 'm68k-linux-musl-objcopy'
+objdump = 'm68k-linux-musl-objdump'
+ranlib = 'm68k-linux-musl-gcc-ranlib'
+readelf = 'm68k-linux-musl-readelf'
+size = 'm68k-linux-musl-size'
+strings = 'm68k-linux-musl-strings'
+strip = 'm68k-linux-musl-strip'
+
+[host_machine]
+cpu = 'm68k'
+cpu_family = 'm68k'
+system = 'linux'
+endian = 'big'

--- a/meson/meson.cross.powerpcle
+++ b/meson/meson.cross.powerpcle
@@ -16,7 +16,7 @@ strings = 'powerpcle-linux-musl-strings'
 strip = 'powerpcle-linux-musl-strip'
 
 [host_machine]
-cpu = 'ppc'
+cpu = 'ppcle'
 cpu_family = 'ppc'
 system = 'linux'
 endian = 'little'

--- a/meson/meson.cross.powerpcle
+++ b/meson/meson.cross.powerpcle
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'powerpcle-linux-musl-gcc-ar'
+as = 'powerpcle-linux-musl-as'
+c = 'powerpcle-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'powerpcle-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'powerpcle-linux-musl-ld.bfd'
+nm = 'powerpcle-linux-musl-gcc-nm'
+objcopy = 'powerpcle-linux-musl-objcopy'
+objdump = 'powerpcle-linux-musl-objdump'
+ranlib = 'powerpcle-linux-musl-gcc-ranlib'
+readelf = 'powerpcle-linux-musl-readelf'
+size = 'powerpcle-linux-musl-size'
+strings = 'powerpcle-linux-musl-strings'
+strip = 'powerpcle-linux-musl-strip'
+
+[host_machine]
+cpu = 'ppc'
+cpu_family = 'ppc'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.sh2
+++ b/meson/meson.cross.sh2
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh2-linux-musl-gcc-ar'
+as = 'sh2-linux-musl-as'
+c = 'sh2-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'sh2-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'sh2-linux-musl-ld.bfd'
+nm = 'sh2-linux-musl-gcc-nm'
+objcopy = 'sh2-linux-musl-objcopy'
+objdump = 'sh2-linux-musl-objdump'
+ranlib = 'sh2-linux-musl-gcc-ranlib'
+readelf = 'sh2-linux-musl-readelf'
+size = 'sh2-linux-musl-size'
+strings = 'sh2-linux-musl-strings'
+strip = 'sh2-linux-musl-strip'
+
+[host_machine]
+cpu = 'sh2'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.sh2-fdpic
+++ b/meson/meson.cross.sh2-fdpic
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh2-linux-muslfdpic-gcc-ar'
+as = 'sh2-linux-muslfdpic-as'
+c = 'sh2-linux-muslfdpic-gcc'
+c_ld = 'bfd'
+cpp = 'sh2-linux-muslfdpic-g++'
+cpp_ld = 'bfd'
+ld = 'sh2-linux-muslfdpic-ld.bfd'
+nm = 'sh2-linux-muslfdpic-gcc-nm'
+objcopy = 'sh2-linux-muslfdpic-objcopy'
+objdump = 'sh2-linux-muslfdpic-objdump'
+ranlib = 'sh2-linux-muslfdpic-gcc-ranlib'
+readelf = 'sh2-linux-muslfdpic-readelf'
+size = 'sh2-linux-muslfdpic-size'
+strings = 'sh2-linux-muslfdpic-strings'
+strip = 'sh2-linux-muslfdpic-strip'
+
+[host_machine]
+cpu = 'sh2'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.sh2eb
+++ b/meson/meson.cross.sh2eb
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh2eb-linux-musl-gcc-ar'
+as = 'sh2eb-linux-musl-as'
+c = 'sh2eb-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'sh2eb-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'sh2eb-linux-musl-ld.bfd'
+nm = 'sh2eb-linux-musl-gcc-nm'
+objcopy = 'sh2eb-linux-musl-objcopy'
+objdump = 'sh2eb-linux-musl-objdump'
+ranlib = 'sh2eb-linux-musl-gcc-ranlib'
+readelf = 'sh2eb-linux-musl-readelf'
+size = 'sh2eb-linux-musl-size'
+strings = 'sh2eb-linux-musl-strings'
+strip = 'sh2eb-linux-musl-strip'
+
+[host_machine]
+cpu = 'sh2eb'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'big'

--- a/meson/meson.cross.sh2eb-fdpic
+++ b/meson/meson.cross.sh2eb-fdpic
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh2eb-linux-muslfdpic-gcc-ar'
+as = 'sh2eb-linux-muslfdpic-as'
+c = 'sh2eb-linux-muslfdpic-gcc'
+c_ld = 'bfd'
+cpp = 'sh2eb-linux-muslfdpic-g++'
+cpp_ld = 'bfd'
+ld = 'sh2eb-linux-muslfdpic-ld.bfd'
+nm = 'sh2eb-linux-muslfdpic-gcc-nm'
+objcopy = 'sh2eb-linux-muslfdpic-objcopy'
+objdump = 'sh2eb-linux-muslfdpic-objdump'
+ranlib = 'sh2eb-linux-muslfdpic-gcc-ranlib'
+readelf = 'sh2eb-linux-muslfdpic-readelf'
+size = 'sh2eb-linux-muslfdpic-size'
+strings = 'sh2eb-linux-muslfdpic-strings'
+strip = 'sh2eb-linux-muslfdpic-strip'
+
+[host_machine]
+cpu = 'sh2eb'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'big'

--- a/meson/meson.cross.sh4
+++ b/meson/meson.cross.sh4
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh4-linux-musl-gcc-ar'
+as = 'sh4-linux-musl-as'
+c = 'sh4-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'sh4-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'sh4-linux-musl-ld.bfd'
+nm = 'sh4-linux-musl-gcc-nm'
+objcopy = 'sh4-linux-musl-objcopy'
+objdump = 'sh4-linux-musl-objdump'
+ranlib = 'sh4-linux-musl-gcc-ranlib'
+readelf = 'sh4-linux-musl-readelf'
+size = 'sh4-linux-musl-size'
+strings = 'sh4-linux-musl-strings'
+strip = 'sh4-linux-musl-strip'
+
+[host_machine]
+cpu = 'sh4'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'little'

--- a/meson/meson.cross.sh4eb
+++ b/meson/meson.cross.sh4eb
@@ -1,0 +1,22 @@
+[binaries]
+ar = 'sh4eb-linux-musl-gcc-ar'
+as = 'sh4eb-linux-musl-as'
+c = 'sh4eb-linux-musl-gcc'
+c_ld = 'bfd'
+cpp = 'sh4eb-linux-musl-g++'
+cpp_ld = 'bfd'
+ld = 'sh4eb-linux-musl-ld.bfd'
+nm = 'sh4eb-linux-musl-gcc-nm'
+objcopy = 'sh4eb-linux-musl-objcopy'
+objdump = 'sh4eb-linux-musl-objdump'
+ranlib = 'sh4eb-linux-musl-gcc-ranlib'
+readelf = 'sh4eb-linux-musl-readelf'
+size = 'sh4eb-linux-musl-size'
+strings = 'sh4eb-linux-musl-strings'
+strip = 'sh4eb-linux-musl-strip'
+
+[host_machine]
+cpu = 'sh4eb'
+cpu_family = 'sh'
+system = 'linux'
+endian = 'big'

--- a/mussel.sh
+++ b/mussel.sh
@@ -206,6 +206,30 @@ while [ $# -gt 0 ]; do
       XPURE64=$XARCH
       XTARGET=$XARCH-linux-musl
       ;;
+    armv4 | armv4t )
+      XARCH=armv4t
+      LARCH=arm
+      MARCH=$LARCH
+      XGCCARGS="--with-arch=armv4t --with-float=soft"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musleabi
+      ;;
+    armv5 | armv5te )
+      XARCH=armv5te
+      LARCH=arm
+      MARCH=$LARCH
+      XGCCARGS="--with-arch=armv5te --with-float=soft"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musleabi
+      ;;
+    armv6 )
+      XARCH=armv6
+      LARCH=arm
+      MARCH=$LARCH
+      XGCCARGS="--with-arch=$XARCH --with-fpu=vfp --with-float=hard"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musleabihf
+      ;;
     arm | armv6kz | armv6zk | bcm2835)
       XARCH=armv6kz
       LARCH=arm
@@ -214,13 +238,21 @@ while [ $# -gt 0 ]; do
       XPURE64=""
       XTARGET=$XARCH-linux-musleabihf
       ;;
-    armv7)
-      XARCH=$1
+    armv7 | armv7-a)
+      XARCH=armv7-a
       LARCH=arm
       MARCH=$LARCH
-      XGCCARGS="--with-arch=${LARCH}v7-a --with-fpu=vfpv3 --with-float=hard"
+      XGCCARGS="--with-arch=$XARCH --with-fpu=vfpv3 --with-float=hard"
       XPURE64=""
       XTARGET=$LARCH-linux-musleabihf
+      ;;
+    i486)
+      XARCH=$1
+      LARCH=i386
+      MARCH=$LARCH
+      XGCCARGS="--with-arch=$1 --with-tune=generic"
+      XPURE64=""
+      XTARGET=$1-linux-musl
       ;;
     i586)
       XARCH=$1
@@ -235,6 +267,14 @@ while [ $# -gt 0 ]; do
       LARCH=i386
       MARCH=$LARCH
       XGCCARGS="--with-arch=$XARCH --with-tune=generic"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musl
+      ;;
+    m68k | 68000 | motorola )
+      XARCH=m68k
+      LARCH=$XARCH
+      MARCH=$XARCH
+      XGCCARGS=""
       XPURE64=""
       XTARGET=$XARCH-linux-musl
       ;;
@@ -302,6 +342,14 @@ while [ $# -gt 0 ]; do
       XPURE64=""
       XTARGET=$XARCH-linux-musl
       ;;
+    powerpcle | powerpcel | ppcle | ppcel )
+      XARCH=powerpcle
+      LARCH=poweroc
+      MARCH=powerpc
+      XGCCARGS="--with-cpu=$LARCH --enable-secureplt --without-long-double-128 --with-endian=little"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musl
+      ;;
     g5 | powerpc64 | powerpc64be | powerpc64eb | ppc64 | ppc64be | ppc64eb)
       XARCH=powerpc64
       LARCH=powerpc
@@ -334,7 +382,55 @@ while [ $# -gt 0 ]; do
       XPURE64=$XARCH
       XTARGET=$XARCH-linux-musl
       ;;
-    x86-64 | x86_64)
+    sh2 | superh | sh2le | sh2el)
+      XARCH=sh2
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS=""
+      XPURE64=""
+      XTARGET=$XARCH-linux-musl
+      ;;
+    sh2-fdpic | superh-fdpic | sh2le-fdpic | sh2el-fdpic)
+      XARCH=sh2
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS=""
+      XPURE64="--enable-fdpic"
+      XTARGET=$XARCH-linux-muslfdpic
+      ;;
+    sh2be | sh2eb)
+      XARCH=sh2eb
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS="--with-endian=big"
+      XPURE64=""
+      XTARGET=$XARCH-linux-musl
+      ;;
+    sh2be-fdpic | sh2eb-fdpic)
+      XARCH=sh2eb
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS="--enable-fdpic --with-endian=big"
+      XPURE64=""
+      XTARGET=$XARCH-linux-muslfdpic
+      ;;
+    sh4 | superh4 | sh4le | sh4el)
+      XARCH=sh4
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS=""
+      XPURE64=""
+      XTARGET=$XARCH-linux-musl
+      ;;
+    sh4be-fdpic | sh4eb-fdpic)
+      XARCH=sh4eb
+      LARCH=sh
+      MARCH=$LARCH
+      XGCCARGS="--with-endian=big"
+      XPURE64=""
+      XTARGET=$XARCH-linux-muslfdpic
+      ;;
+    amd64 | x86-64 | x86_64)
       XARCH=x86-64
       LARCH=x86_64
       MARCH=$LARCH
@@ -362,11 +458,16 @@ while [ $# -gt 0 ]; do
       printf -- '\n'
       printf -- 'Supported Architectures:\n'
       printf -- '\t+ aarch64\n'
+      printf -- '\t+ armv4t\n'
+      printf -- '\t+ armv5te\n'
+      printf -- '\t+ armv6\n'
       printf -- '\t+ armv6kz (Raspberry Pi 1 Models A, B, B+, the Compute Module,'
       printf -- '\n\t          and the Raspberry Pi Zero)\n'
       printf -- '\t+ armv7\n'
+      printf -- '\t+ i486\n'
       printf -- '\t+ i586\n'
       printf -- '\t+ i686\n'
+      printf -- '\t+ m68k\n'
       printf -- '\t+ microblaze\n'
       printf -- '\t+ microblazeel\n'
       printf -- '\t+ mips64\n'
@@ -375,10 +476,17 @@ while [ $# -gt 0 ]; do
       printf -- '\t+ mipsisa64r6el\n'
       printf -- '\t+ or1k\n'
       printf -- '\t+ powerpc\n'
+      printf -- '\t+ powerpcle\n'
       printf -- '\t+ powerpc64\n'
       printf -- '\t+ powerpc64le\n'
       printf -- '\t+ riscv64\n'
       printf -- '\t+ s390x\n'
+      printf -- '\t+ sh2\n'
+      printf -- '\t+ sh2be\n'
+      printf -- '\t+ sh2-fdpic\n'
+      printf -- '\t+ sh2be-fdpic\n'
+      printf -- '\t+ sh4\n'
+      printf -- '\t+ sh4be\n'
       printf -- '\t+ x86-64\n'
       printf -- '\n'
       printf -- 'Flags:\n'

--- a/mussel.sh
+++ b/mussel.sh
@@ -52,39 +52,44 @@ mpfr_url=https://www.mpfr.org/mpfr-current/mpfr-$mpfr_ver.tar.xz
 musl_url=https://www.musl-libc.org/releases/musl-$musl_ver.tar.gz
 pkgconf_url=https://distfiles.dereferenced.org/pkgconf/pkgconf-$pkgconf_ver.tar.xz
 
-if command -v b3sum 2>&1 > /dev/null; then
-# ----- Package Checksums (b3sum) ----- #
-binutils_sum=41ff0592df8c1e8ec5eb086d418e792331c0c49040218462d6c1224b4fa36d04
-gcc_sum=875af4d704560973ada577955392735ded87e6fd304bd0cbaf8ac795390501c7
-gmp_sum=fffe4996713928ae19331c8ef39129e46d3bf5b7182820656fd4639435cd83a4
-isl_sum=a27da5d097f4e105d3a63c5e81d26c2b00cc35a4a3bf62dd2a49335a0f20ce7f
-linux_sum=b063c7ca0986358f22e9019617cbadb3404da6eb44133bee789f9c7565b1c121
-mpc_sum=86d083c43c08e98d4470c006a01e0df727c8ff56ddd2956b170566ba8c9a46de
-mpfr_sum=f428023b8f7569fc1178faf63265ecb6cab4505fc3fce5d8c46af70db848a334
-musl_sum=fc33d5ebf5812ddc4a409b5e5abe620e216ad0378273fdafb73795d52e1722c6
-pkgconf_sum=6c462df0a2d2e1a384cea44c775ef6991be31f21b5bde515f175e6ac6fdb1164
-elif (command -v sha256sum || command -v openssl) 2>&1 > /dev/null; then
-# ----- Package Checksums (sha256sum) ----- #
-binutils_sum=f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800
-gcc_sum=e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da
-gmp_sum=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
-isl_sum=a0b5cb06d24f9fa9e77b55fabbe9a3c94a336190345c2555f9915bb38e976504
-linux_sum=4cac13f7b17bd8dcf9032ad68f9123ab5313d698c9f59416043165150763eb4f
-mpc_sum=ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
-mpfr_sum=277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
-musl_sum=7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039
-pkgconf_sum=266d5861ee51c52bc710293a1d36622ae16d048d71ec56034a02eb9cf9677761
+# Decide which checksum command to use.
+if [ -z "$checksum_command" ]; then
+	for ccmd in openssl sha256sum b3sum; do
+		command -v $ccmd  2>&1 > /dev/null && checksum_command="$ccmd"
+	done
 fi
 
+# checksums
+if [ "$checksum_command" = "b3sum" ]; then
+  # ----- Package Checksums (b3sum) ----- #
+  binutils_sum=41ff0592df8c1e8ec5eb086d418e792331c0c49040218462d6c1224b4fa36d04
+  gcc_sum=875af4d704560973ada577955392735ded87e6fd304bd0cbaf8ac795390501c7
+  gmp_sum=fffe4996713928ae19331c8ef39129e46d3bf5b7182820656fd4639435cd83a4
+  isl_sum=a27da5d097f4e105d3a63c5e81d26c2b00cc35a4a3bf62dd2a49335a0f20ce7f
+  linux_sum=b063c7ca0986358f22e9019617cbadb3404da6eb44133bee789f9c7565b1c121
+  mpc_sum=86d083c43c08e98d4470c006a01e0df727c8ff56ddd2956b170566ba8c9a46de
+  mpfr_sum=f428023b8f7569fc1178faf63265ecb6cab4505fc3fce5d8c46af70db848a334
+  musl_sum=fc33d5ebf5812ddc4a409b5e5abe620e216ad0378273fdafb73795d52e1722c6
+  pkgconf_sum=6c462df0a2d2e1a384cea44c775ef6991be31f21b5bde515f175e6ac6fdb1164
 
-# ----- Checksum utility alias ----- #
-if command -v b3sum 2>&1 > /dev/null; then
-checksum(){ b3sum -c "$@"; }
-elif command -v openssl 2>&1 > /dev/null; then
+elif [ "$checksum_command" = "sha256sum" ] || [ "$checksum_command" = "openssl" ]; then
+  # ----- Package Checksums (sha256sum) ----- #
+  binutils_sum=f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800
+  gcc_sum=e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da
+  gmp_sum=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
+  isl_sum=a0b5cb06d24f9fa9e77b55fabbe9a3c94a336190345c2555f9915bb38e976504
+  linux_sum=4cac13f7b17bd8dcf9032ad68f9123ab5313d698c9f59416043165150763eb4f
+  mpc_sum=ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
+  mpfr_sum=277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
+  musl_sum=7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039
+  pkgconf_sum=266d5861ee51c52bc710293a1d36622ae16d048d71ec56034a02eb9cf9677761
+fi
+
+# ----- Check sha256 hash using openssl ----- #
 # For a simple formality, I must say this code comes from Copacabana's
 # build-system cmd/sha256sum.ksh implementation, but was heavly modified
 # for POSIX shell compliance and for fitting this script.
-checksum(){
+osslchecksum() {
 	err=0
 	# If it's not passed via $1, read it from standard input using cat(1).
 	hash_line="${1:-$(cat)}"
@@ -108,9 +113,39 @@ checksum(){
 	actual_hash_line actual_fname actual_hash
 	return $err
 }
-elif command -v sha256sum 2>&1 > /dev/null; then
-checksum(){ sha256sum -c "$@"; }
-fi
+
+# ----- Checksum utility alias ----- #
+checksum() {
+  # check the hash with b3sum
+  [ "$checksum_command" = "b3sum" ] && {
+    printf "$1  $2" | b3sum -c
+    return $?
+  }
+
+  # check the hash with sha256sum
+  [ "$checksum_command" = "sha256sum" ] && {
+    printf "$1  $2" | sha256sum -c
+    return $?
+  }
+
+
+  # check the hash with openssl
+  [ "$checksum_command" = "openssl" ] && {
+    printf "$1 $2" | osslchecksum
+    return $?
+  }
+}
+
+# Stone-portable way to get the processor number of cores on
+# UNIX-compatible systems, although we may only be using this on Linux.
+getnproc() {
+	(
+		getconf _NPROCESSORS_ONLN \
+		|| ( [ "$(uname -s)" = 'Linux' ] && printf -- '%d' $(grep -c 'processor' /proc/cpuinfo) ) \
+		|| nproc \
+		|| printf -- '%d' 1
+	) 2>/dev/null
+}
 
 # Decide which download command to use.
 if [ -z "$download_command" ]; then
@@ -130,17 +165,6 @@ if [ -z "$download_command" ]; then
 		'https://www.gnu.org/software/wget/ (C'\''mon, it'\''s better than nothing)'
 	exit 1
 fi
-
-# Stone-portable way to get the processor number of cores on
-# UNIX-compatible systems, although we may only be using this on Linux.
-getnproc() {
-	(
-		getconf _NPROCESSORS_ONLN \
-		|| ( [ "$(uname -s)" = 'Linux' ] && printf -- '%d' $(grep -c 'processor' /proc/cpuinfo) ) \
-		|| nproc \
-		|| printf -- '%d' 1
-	) 2>/dev/null
-}
 
 # ----- URL transfer utility alias ----- #
 nettransfer() {
@@ -573,7 +597,7 @@ mpackage() {
   fi
 
   printf -- "${BLUEC}..${NORMALC} Verifying "$HOLDER"...\n"
-  printf -- "$3  $HOLDER" | checksum || {
+  checksum "$3" "$HOLDER" || {
     printf -- "${YELLOWC}!.${NORMALC} "$HOLDER" is corrupted, redownloading...\n" &&
     rm "$HOLDER" &&
     nettransfer "$2";

--- a/mussel.sh
+++ b/mussel.sh
@@ -415,12 +415,12 @@ while [ $# -gt 0 ]; do
       XTARGET=$XARCH-linux-musl
       ;;
     sh2-fdpic | superh-fdpic | sh2le-fdpic | sh2el-fdpic)
-      XARCH=sh2
+      XARCH=sh2-fdpic
       LARCH=sh
       MARCH=$LARCH
       XGCCARGS=""
       XPURE64="--enable-fdpic"
-      XTARGET=$XARCH-linux-muslfdpic
+      XTARGET=sh2-linux-muslfdpic
       ;;
     sh2be | sh2eb)
       XARCH=sh2eb
@@ -431,12 +431,12 @@ while [ $# -gt 0 ]; do
       XTARGET=$XARCH-linux-musl
       ;;
     sh2be-fdpic | sh2eb-fdpic)
-      XARCH=sh2eb
+      XARCH=sh2eb-fdpic
       LARCH=sh
       MARCH=$LARCH
       XGCCARGS="--enable-fdpic --with-endian=big"
       XPURE64=""
-      XTARGET=$XARCH-linux-muslfdpic
+      XTARGET=sh2eb-linux-muslfdpic
       ;;
     sh4 | superh4 | sh4le | sh4el)
       XARCH=sh4


### PR DESCRIPTION
- Added targets **armv4t**, **armv5te**, **armv6**, **i486**, **m68k**, **powerpcle**, **sh2**, **sh2be**, **sh2-fdpic**, **sh2be-fdpic**, **sh4**, and **sh4be**. I chose the `XGCCARGS` values based on what's done by [richfelker/musl-cross-make:litecross/Makefile](https://github.com/richfelker/musl-cross-make/blob/master/litecross/Makefile) and the compilers hosted at [musl.cc](https://musl.cc). I'm pretty sure that these new targets are ABI-compliant as they run correctly under `qemu`, but I don't have physical hardware to test these on so the `XGCCARGS` variables might need to be tweaked a little.
- Fixed #24 without breaking #18, since the double-space between the hash and the filename is required for `b3sum`, but incompatible with the `openssl` hash checking method (which I also moved to a new function, `osslchecksum()`, for clarity). Now, instead of reading STDIN, `checksum()` takes two command line arguments which it passes to whichever hashing function correctly.